### PR TITLE
Navigation Issue with onTap Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* When the "OK" button is pressed, the developer can choose to either close the dialog or keep it open.
+
 ## 1.1.1
 
 * fix some warning

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,6 +44,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   startTime = from.hour.toString();
                   endTime = to.hour.toString();
                 });
+                Navigator.pop(context);
               },
             ));
   }
@@ -58,6 +59,7 @@ class _MyHomePageState extends State<MyHomePage> {
             startTime = from.hour.toString();
             endTime = to.hour.toString();
           });
+          Navigator.pop(context);
         },
         dialogBackgroundColor: Color(0xFF121212),
         fromHeadlineColor: Colors.white,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   fluintl:
     dependency: transitive
     description:
@@ -87,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.2"
   intl:
     dependency: transitive
     description:
@@ -108,28 +101,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,7 +134,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -162,21 +155,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/from_to_picker_src.dart
+++ b/lib/src/from_to_picker_src.dart
@@ -282,8 +282,7 @@ class _FromToTimePickerState extends State<FromToTimePicker> {
                             generate24HTime(
                                 isAmFrom, timePickerStartTime.toString()),
                             generate24HTime(
-                                isAmTo, timePickerEndTime.toString()));
-                        Navigator.pop(context);
+                                isAmTo, timePickerEndTime.toString()));                        
                       },
                       child: Text(
                         widget.doneText!,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: from_to_time_picker
 description: Simple duration time range picker that enable user pick start time and end time of day in both 24h and 12h format
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/ahmedElsarag/from_to_time_picker
 
 environment:


### PR DESCRIPTION
The issue is that calling onTap method followed by Navigator.pop(context) prevents navigating to a new screen. To allow the user to close the first dialog and then go to a new screen, the order of these calls needs to be changed.

`onTap: (){
  // go to new screen
}`
after opening new screen it close screen immediately due to calling 
`pop` method after calling `onTap` method in from_to_time_picker package.